### PR TITLE
Improve Volley header handling. (#91)

### DIFF
--- a/src/main/java/com/android/volley/Cache.java
+++ b/src/main/java/com/android/volley/Cache.java
@@ -17,6 +17,7 @@
 package com.android.volley;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -83,8 +84,21 @@ public interface Cache {
         /** Soft TTL for this record. */
         public long softTtl;
 
-        /** Immutable response headers as received from server; must be non-null. */
+        /**
+         * Response headers as received from server; must be non-null. Should not be mutated
+         * directly.
+         *
+         * <p>Note that if the server returns two headers with the same (case-insensitive) name,
+         * this map will only contain the one of them. {@link #allResponseHeaders} may contain all
+         * headers if the {@link Cache} implementation supports it.
+         */
         public Map<String, String> responseHeaders = Collections.emptyMap();
+
+        /**
+         * All response headers. May be null depending on the {@link Cache} implementation. Should
+         * not be mutated directly.
+         */
+        public List<Header> allResponseHeaders;
 
         /** True if the entry is expired. */
         public boolean isExpired() {

--- a/src/main/java/com/android/volley/Header.java
+++ b/src/main/java/com/android/volley/Header.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.volley;
+
+import android.text.TextUtils;
+
+/** An HTTP header. */
+public final class Header {
+    private final String mName;
+    private final String mValue;
+
+    public Header(String name, String value) {
+        mName = name;
+        mValue = value;
+    }
+
+    public final String getName() {
+        return mName;
+    }
+
+    public final String getValue() {
+        return mValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Header header = (Header) o;
+
+        return TextUtils.equals(mName, header.mName)
+                && TextUtils.equals(mValue, header.mValue);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mName.hashCode();
+        result = 31 * result + mValue.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Header[name=" + mName + ",value=" + mValue + "]";
+    }
+}

--- a/src/main/java/com/android/volley/NetworkResponse.java
+++ b/src/main/java/com/android/volley/NetworkResponse.java
@@ -17,13 +17,17 @@
 package com.android.volley;
 
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Data and headers returned from {@link Network#performRequest(Request)}.
  */
 public class NetworkResponse {
+
     /**
      * Creates a new network response.
      * @param statusCode the HTTP status code
@@ -31,27 +35,74 @@ public class NetworkResponse {
      * @param headers Headers returned with this response, or null for none
      * @param notModified True if the server returned a 304 and the data was already in cache
      * @param networkTimeMs Round-trip network time to receive network response
+     * @deprecated see {@link #NetworkResponse(int, byte[], List, boolean, long)}. This constructor
+     *             cannot handle server responses containing multiple headers with the same name.
+     *             This constructor may be removed in a future release of Volley.
      */
+    @Deprecated
     public NetworkResponse(int statusCode, byte[] data, Map<String, String> headers,
             boolean notModified, long networkTimeMs) {
-        this.statusCode = statusCode;
-        this.data = data;
-        this.headers = headers;
-        this.notModified = notModified;
-        this.networkTimeMs = networkTimeMs;
+        this(statusCode, data, headers, toAllHeaderList(headers), notModified, networkTimeMs);
     }
 
+    /**
+     * Creates a new network response.
+     * @param statusCode the HTTP status code
+     * @param data Response body
+     * @param allHeaders All headers returned with this response, or null for none
+     * @param notModified True if the server returned a 304 and the data was already in cache
+     * @param networkTimeMs Round-trip network time to receive network response
+     */
+    public NetworkResponse(int statusCode, byte[] data, List<Header> allHeaders,
+            boolean notModified, long networkTimeMs) {
+        this(statusCode, data, toHeaderMap(allHeaders), allHeaders, notModified, networkTimeMs);
+    }
+
+    /**
+     * Creates a new network response.
+     * @param statusCode the HTTP status code
+     * @param data Response body
+     * @param headers Headers returned with this response, or null for none
+     * @param notModified True if the server returned a 304 and the data was already in cache
+     * @deprecated see {@link #NetworkResponse(int, byte[], List, boolean, long)}. This constructor
+     *             cannot handle server responses containing multiple headers with the same name.
+     *             This constructor may be removed in a future release of Volley.
+     */
+    @Deprecated
     public NetworkResponse(int statusCode, byte[] data, Map<String, String> headers,
             boolean notModified) {
         this(statusCode, data, headers, notModified, 0);
     }
 
+    /**
+     * Creates a new network response for an OK response with no headers.
+     * @param data Response body
+     */
     public NetworkResponse(byte[] data) {
-        this(HttpURLConnection.HTTP_OK, data, Collections.<String, String>emptyMap(), false, 0);
+        this(HttpURLConnection.HTTP_OK, data, Collections.<Header>emptyList(), false, 0);
     }
 
+    /**
+     * Creates a new network response for an OK response.
+     * @param data Response body
+     * @param headers Headers returned with this response, or null for none
+     * @deprecated see {@link #NetworkResponse(int, byte[], List, boolean, long)}. This constructor
+     *             cannot handle server responses containing multiple headers with the same name.
+     *             This constructor may be removed in a future release of Volley.
+     */
+    @Deprecated
     public NetworkResponse(byte[] data, Map<String, String> headers) {
         this(HttpURLConnection.HTTP_OK, data, headers, false, 0);
+    }
+
+    private NetworkResponse(int statusCode, byte[] data, Map<String, String> headers,
+            List<Header> allHeaders, boolean notModified, long networkTimeMs) {
+        this.statusCode = statusCode;
+        this.data = data;
+        this.headers = headers;
+        this.allHeaders = Collections.unmodifiableList(allHeaders);
+        this.notModified = notModified;
+        this.networkTimeMs = networkTimeMs;
     }
 
     /** The HTTP status code. */
@@ -60,13 +111,41 @@ public class NetworkResponse {
     /** Raw data from this response. */
     public final byte[] data;
 
-    /** Response headers. */
+    /**
+     * Response headers.
+     *
+     * <p>This map is case-insensitive. It should not be mutated directly.
+     *
+     * <p>Note that if the server returns two headers with the same (case-insensitive) name, this
+     * map will only contain the last one. Use {@link #allHeaders} to inspect all headers returned
+     * by the server.
+     */
     public final Map<String, String> headers;
+
+    /** All response headers. Must not be mutated directly. */
+    public final List<Header> allHeaders;
 
     /** True if the server returned a 304 (Not Modified). */
     public final boolean notModified;
 
     /** Network roundtrip time in milliseconds. */
     public final long networkTimeMs;
+
+    private static Map<String, String> toHeaderMap(List<Header> allHeaders) {
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        // Later elements in the list take precedence.
+        for (Header header : allHeaders) {
+            headers.put(header.getName(), header.getValue());
+        }
+        return headers;
+    }
+
+    private static List<Header> toAllHeaderList(Map<String, String> headers) {
+        List<Header> allHeaders = new ArrayList<>(headers.size());
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            allHeaders.add(new Header(header.getKey(), header.getValue()));
+        }
+        return allHeaders;
+    }
 }
 

--- a/src/main/java/com/android/volley/toolbox/AdaptedHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/AdaptedHttpStack.java
@@ -16,9 +16,9 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.Header;
 import com.android.volley.Request;
 
-import org.apache.http.Header;
 import org.apache.http.conn.ConnectTimeoutException;
 
 import java.io.IOException;
@@ -58,19 +58,14 @@ class AdaptedHttpStack extends BaseHttpStack {
 
         int statusCode = apacheResp.getStatusLine().getStatusCode();
 
-        Header[] headers = apacheResp.getAllHeaders();
-        Map<String, List<String>> headerMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        for (Header header : headers) {
-            List<String> valueList = headerMap.get(header.getName());
-            if (valueList == null) {
-                valueList = new ArrayList<>();
-                headerMap.put(header.getName(), valueList);
-            }
-            valueList.add(header.getValue());
+        org.apache.http.Header[] headers = apacheResp.getAllHeaders();
+        List<Header> headerList = new ArrayList<>(headers.length);
+        for (org.apache.http.Header header : headers) {
+            headerList.add(new Header(header.getName(), header.getValue()));
         }
 
         if (apacheResp.getEntity() == null) {
-            return new HttpResponse(statusCode, headerMap);
+            return new HttpResponse(statusCode, headerList);
         }
 
         long contentLength = apacheResp.getEntity().getContentLength();
@@ -80,7 +75,7 @@ class AdaptedHttpStack extends BaseHttpStack {
 
         return new HttpResponse(
                 statusCode,
-                headerMap,
+                headerList,
                 (int) apacheResp.getEntity().getContentLength(),
                 apacheResp.getEntity().getContent());
     }

--- a/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
@@ -16,9 +16,9 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.Header;
 import com.android.volley.Request;
 
-import org.apache.http.Header;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.entity.BasicHttpEntity;
@@ -74,13 +74,11 @@ public abstract class BaseHttpStack implements HttpStack {
                 protocolVersion, response.getStatusCode(), "" /* reasonPhrase */);
         BasicHttpResponse apacheResponse = new BasicHttpResponse(statusLine);
 
-        List<Header> headers = new ArrayList<>();
-        for (Map.Entry<String, List<String>> entry : response.getHeaders().entrySet()) {
-            for (String value : entry.getValue()) {
-                headers.add(new BasicHeader(entry.getKey(), value));
-            }
+        List<org.apache.http.Header> headers = new ArrayList<>();
+        for (Header header : response.getHeaders()) {
+            headers.add(new BasicHeader(header.getName(), header.getValue()));
         }
-        apacheResponse.setHeaders(headers.toArray(new Header[headers.size()]));
+        apacheResponse.setHeaders(headers.toArray(new org.apache.http.Header[headers.size()]));
 
         InputStream responseStream = response.getContent();
         if (responseStream != null) {

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -22,6 +22,7 @@ import com.android.volley.AuthFailureError;
 import com.android.volley.Cache;
 import com.android.volley.Cache.Entry;
 import com.android.volley.ClientError;
+import com.android.volley.Header;
 import com.android.volley.Network;
 import com.android.volley.NetworkError;
 import com.android.volley.NetworkResponse;
@@ -33,18 +34,19 @@ import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 import com.android.volley.VolleyLog;
 
-import org.apache.http.Header;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * A network performing Volley requests over an {@link HttpStack}.
@@ -121,32 +123,27 @@ public class BasicNetwork implements Network {
         while (true) {
             HttpResponse httpResponse = null;
             byte[] responseContents = null;
-            Map<String, String> responseHeaders = Collections.emptyMap();
+            List<Header> responseHeaders = Collections.emptyList();
             try {
                 // Gather headers.
-                Map<String, String> headers = new HashMap<>();
-                addCacheHeaders(headers, request.getCacheEntry());
-                httpResponse = mBaseHttpStack.executeRequest(request, headers);
+                Map<String, String> additionalRequestHeaders =
+                        getCacheHeaders(request.getCacheEntry());
+                httpResponse = mBaseHttpStack.executeRequest(request, additionalRequestHeaders);
                 int statusCode = httpResponse.getStatusCode();
 
-                responseHeaders = convertHeaders(httpResponse.getHeaders());
+                responseHeaders = httpResponse.getHeaders();
                 // Handle cache validation.
                 if (statusCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
-
                     Entry entry = request.getCacheEntry();
                     if (entry == null) {
                         return new NetworkResponse(HttpURLConnection.HTTP_NOT_MODIFIED, null,
                                 responseHeaders, true,
                                 SystemClock.elapsedRealtime() - requestStart);
                     }
-
-                    // A HTTP 304 response does not have all header fields. We
-                    // have to use the header fields from the cache entry plus
-                    // the new ones from the response.
-                    // http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5
-                    entry.responseHeaders.putAll(responseHeaders);
+                    // Combine cached and response headers so the response will be complete.
+                    List<Header> combinedHeaders = combineHeaders(responseHeaders, entry);
                     return new NetworkResponse(HttpURLConnection.HTTP_NOT_MODIFIED, entry.data,
-                            entry.responseHeaders, true,
+                            combinedHeaders, true,
                             SystemClock.elapsedRealtime() - requestStart);
                 }
 
@@ -244,11 +241,13 @@ public class BasicNetwork implements Network {
         request.addMarker(String.format("%s-retry [timeout=%s]", logPrefix, oldTimeout));
     }
 
-    private void addCacheHeaders(Map<String, String> headers, Cache.Entry entry) {
+    private Map<String, String> getCacheHeaders(Cache.Entry entry) {
         // If there's no cache entry, we're done.
         if (entry == null) {
-            return;
+            return Collections.emptyMap();
         }
+
+        Map<String, String> headers = new HashMap<>();
 
         if (entry.etag != null) {
             headers.put("If-None-Match", entry.etag);
@@ -258,6 +257,8 @@ public class BasicNetwork implements Network {
             headers.put("If-Modified-Since",
                     HttpHeaderParser.formatEpochAsRfc1123(entry.lastModified));
         }
+
+        return headers;
     }
 
     protected void logError(String what, String url, long start) {
@@ -303,7 +304,6 @@ public class BasicNetwork implements Network {
      * @deprecated Should never have been exposed in the API. This method may be removed in a future
      *             release of Volley.
      */
-    // Visible for testing (see HttpHeaderParserTest).
     @Deprecated
     protected static Map<String, String> convertHeaders(Header[] headers) {
         Map<String, String> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -313,16 +313,49 @@ public class BasicNetwork implements Network {
         return result;
     }
 
-    // TODO(#21): Pass all headers to NetworkResponse so clients can access all the headers with
-    // the same keys (e.g. for SetCookie headers). Just need to ensure case-insensitivity.
-    private static Map<String, String> convertHeaders(Map<String, List<String>> headers) {
-        Map<String, String> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
-            if (entry.getKey() != null) {
-                List<String> values = entry.getValue();
-                result.put(entry.getKey(), values.get(0));
+    /**
+     * Combine cache headers with network response headers for an HTTP 304 response.
+     *
+     * <p>An HTTP 304 response does not have all header fields. We have to use the header fields
+     * from the cache entry plus the new ones from the response. See also:
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5
+     *
+     * @param responseHeaders Headers from the network response.
+     * @param entry The cached response.
+     * @return The combined list of headers.
+     */
+    private static List<Header> combineHeaders(List<Header> responseHeaders, Entry entry) {
+        // First, create a case-insensitive set of header names from the network
+        // response.
+        Set<String> headerNamesFromNetworkResponse =
+                new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        if (!responseHeaders.isEmpty()) {
+            for (Header header : responseHeaders) {
+                headerNamesFromNetworkResponse.add(header.getName());
             }
         }
-        return result;
+
+        // Second, add headers from the cache entry to the network response as long as
+        // they didn't appear in the network response, which should take precedence.
+        List<Header> combinedHeaders = new ArrayList<>(responseHeaders);
+        if (entry.allResponseHeaders != null) {
+            if (!entry.allResponseHeaders.isEmpty()) {
+                for (Header header : entry.allResponseHeaders) {
+                    if (!headerNamesFromNetworkResponse.contains(header.getName())) {
+                        combinedHeaders.add(header);
+                    }
+                }
+            }
+        } else {
+            // Legacy caches only have entry.responseHeaders.
+            if (!entry.responseHeaders.isEmpty()) {
+                for (Map.Entry<String, String> header : entry.responseHeaders.entrySet()) {
+                    if (!headerNamesFromNetworkResponse.contains(header.getKey())) {
+                        combinedHeaders.add(new Header(header.getKey(), header.getValue()));
+                    }
+                }
+            }
+        }
+        return combinedHeaders;
     }
 }

--- a/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
@@ -17,15 +17,19 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.Cache;
+import com.android.volley.Header;
 import com.android.volley.NetworkResponse;
 import com.android.volley.VolleyLog;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.TreeMap;
 
 /**
  * Utility methods for parsing HTTP headers.
@@ -124,6 +128,7 @@ public class HttpHeaderParser {
         entry.serverDate = serverDate;
         entry.lastModified = lastModified;
         entry.responseHeaders = headers;
+        entry.allResponseHeaders = response.allHeaders;
 
         return entry;
     }
@@ -185,5 +190,27 @@ public class HttpHeaderParser {
      */
     public static String parseCharset(Map<String, String> headers) {
         return parseCharset(headers, DEFAULT_CONTENT_CHARSET);
+    }
+
+    // Note - these are copied from NetworkResponse to avoid making them public (as needed to access
+    // them from the .toolbox package), which would mean they'd become part of the Volley API.
+    // TODO: Consider obfuscating official releases so we can share utility methods between Volley
+    // and Toolbox without making them public APIs.
+
+    static Map<String, String> toHeaderMap(List<Header> allHeaders) {
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        // Later elements in the list take precedence.
+        for (Header header : allHeaders) {
+            headers.put(header.getName(), header.getValue());
+        }
+        return headers;
+    }
+
+    static List<Header> toAllHeaderList(Map<String, String> headers) {
+        List<Header> allHeaders = new ArrayList<>(headers.size());
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            allHeaders.add(new Header(header.getKey(), header.getValue()));
+        }
+        return allHeaders;
     }
 }

--- a/src/main/java/com/android/volley/toolbox/HttpResponse.java
+++ b/src/main/java/com/android/volley/toolbox/HttpResponse.java
@@ -15,14 +15,17 @@
  */
 package com.android.volley.toolbox;
 
+import com.android.volley.Header;
+
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /** A response from an HTTP server. */
-public class HttpResponse {
+public final class HttpResponse {
+
     private final int mStatusCode;
-    private final Map<String, List<String>> mHeaders;
+    private final List<Header> mHeaders;
     private final int mContentLength;
     private final InputStream mContent;
 
@@ -32,7 +35,7 @@ public class HttpResponse {
      * @param statusCode the HTTP status code of the response
      * @param headers the response headers
      */
-    public HttpResponse(int statusCode, Map<String, List<String>> headers) {
+    public HttpResponse(int statusCode, List<Header> headers) {
         this(statusCode, headers, -1 /* contentLength */, null /* content */);
     }
 
@@ -45,8 +48,8 @@ public class HttpResponse {
      * @param content an {@link InputStream} of the response content. May be null to indicate that
      *     the response has no content.
      */
-    public HttpResponse(int statusCode, Map<String, List<String>> headers,
-            int contentLength, InputStream content) {
+    public HttpResponse(
+            int statusCode, List<Header> headers, int contentLength, InputStream content) {
         mStatusCode = statusCode;
         mHeaders = headers;
         mContentLength = contentLength;
@@ -58,9 +61,9 @@ public class HttpResponse {
         return mStatusCode;
     }
 
-    /** Returns the response headers. */
-    public final Map<String, List<String>> getHeaders() {
-        return mHeaders;
+    /** Returns the response headers. Must not be mutated directly. */
+    public final List<Header> getHeaders() {
+        return Collections.unmodifiableList(mHeaders);
     }
 
     /** Returns the length of the content. Only valid if {@link #getContent} is non-null. */

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -17,6 +17,7 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.Request.Method;
 
@@ -25,7 +26,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -99,12 +102,26 @@ public class HurlStack extends BaseHttpStack {
             // Signal to the caller that something was wrong with the connection.
             throw new IOException("Could not retrieve response code from HttpUrlConnection.");
         }
+
+
+
         if (!hasResponseBody(request.getMethod(), responseCode)) {
-            return new HttpResponse(responseCode, connection.getHeaderFields());
+            return new HttpResponse(responseCode, convertHeaders(connection.getHeaderFields()));
         }
 
-        return new HttpResponse(responseCode, connection.getHeaderFields(),
+        return new HttpResponse(responseCode, convertHeaders(connection.getHeaderFields()),
                 connection.getContentLength(), inputStreamFromConnection(connection));
+    }
+
+    // VisibleForTesting
+    static List<Header> convertHeaders(Map<String, List<String>> responseHeaders) {
+        List<Header> headerList = new ArrayList<>(responseHeaders.size());
+        for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
+            for (String value : entry.getValue()) {
+                headerList.add(new Header(entry.getKey(), value));
+            }
+        }
+        return headerList;
     }
 
     /**

--- a/src/test/java/com/android/volley/toolbox/AdaptedHttpStackTest.java
+++ b/src/test/java/com/android/volley/toolbox/AdaptedHttpStackTest.java
@@ -2,10 +2,10 @@ package com.android.volley.toolbox;
 
 import android.util.Pair;
 
+import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.mock.TestRequest;
 
-import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
@@ -68,13 +68,13 @@ public class AdaptedHttpStackTest {
     public void emptyResponse() throws Exception {
         when(mHttpStack.performRequest(REQUEST, ADDITIONAL_HEADERS)).thenReturn(mHttpResponse);
         when(mStatusLine.getStatusCode()).thenReturn(12345);
-        when(mHttpResponse.getAllHeaders()).thenReturn(new Header[0]);
+        when(mHttpResponse.getAllHeaders()).thenReturn(new org.apache.http.Header[0]);
 
         com.android.volley.toolbox.HttpResponse response =
                 mAdaptedHttpStack.executeRequest(REQUEST, ADDITIONAL_HEADERS);
 
         assertEquals(12345, response.getStatusCode());
-        assertEquals(Collections.emptyMap(), response.getHeaders());
+        assertEquals(Collections.emptyList(), response.getHeaders());
         assertNull(response.getContent());
     }
 
@@ -82,7 +82,7 @@ public class AdaptedHttpStackTest {
     public void nonEmptyResponse() throws Exception {
         when(mHttpStack.performRequest(REQUEST, ADDITIONAL_HEADERS)).thenReturn(mHttpResponse);
         when(mStatusLine.getStatusCode()).thenReturn(12345);
-        when(mHttpResponse.getAllHeaders()).thenReturn(new Header[0]);
+        when(mHttpResponse.getAllHeaders()).thenReturn(new org.apache.http.Header[0]);
         when(mHttpResponse.getEntity()).thenReturn(mHttpEntity);
         when(mHttpEntity.getContentLength()).thenReturn((long) Integer.MAX_VALUE);
         when(mHttpEntity.getContent()).thenReturn(mContent);
@@ -91,7 +91,7 @@ public class AdaptedHttpStackTest {
                 mAdaptedHttpStack.executeRequest(REQUEST, ADDITIONAL_HEADERS);
 
         assertEquals(12345, response.getStatusCode());
-        assertEquals(Collections.emptyMap(), response.getHeaders());
+        assertEquals(Collections.emptyList(), response.getHeaders());
         assertEquals(Integer.MAX_VALUE, response.getContentLength());
         assertSame(mContent, response.getContent());
     }
@@ -100,7 +100,7 @@ public class AdaptedHttpStackTest {
     public void responseTooBig() throws Exception {
         when(mHttpStack.performRequest(REQUEST, ADDITIONAL_HEADERS)).thenReturn(mHttpResponse);
         when(mStatusLine.getStatusCode()).thenReturn(12345);
-        when(mHttpResponse.getAllHeaders()).thenReturn(new Header[0]);
+        when(mHttpResponse.getAllHeaders()).thenReturn(new org.apache.http.Header[0]);
         when(mHttpResponse.getEntity()).thenReturn(mHttpEntity);
         when(mHttpEntity.getContentLength()).thenReturn(Integer.MAX_VALUE + 1L);
         when(mHttpEntity.getContent()).thenReturn(mContent);
@@ -112,7 +112,7 @@ public class AdaptedHttpStackTest {
     public void responseWithHeaders() throws Exception {
         when(mHttpStack.performRequest(REQUEST, ADDITIONAL_HEADERS)).thenReturn(mHttpResponse);
         when(mStatusLine.getStatusCode()).thenReturn(12345);
-        when(mHttpResponse.getAllHeaders()).thenReturn(new Header[] {
+        when(mHttpResponse.getAllHeaders()).thenReturn(new org.apache.http.Header[] {
                 new BasicHeader("header1", "value1_B"),
                 new BasicHeader("header3", "value3"),
                 new BasicHeader("HEADER2", "value2"),
@@ -125,18 +125,11 @@ public class AdaptedHttpStackTest {
         assertEquals(12345, response.getStatusCode());
         assertNull(response.getContent());
 
-        List<Pair<String, String>> orderedHeaders = new ArrayList<>();
-        for (Map.Entry<String, List<String>> entry : response.getHeaders().entrySet()) {
-            for (String value : entry.getValue()) {
-                orderedHeaders.add(Pair.create(entry.getKey(), value));
-            }
-        }
-
-        List<Pair<String, String>> expectedHeaders = new ArrayList<>();
-        expectedHeaders.add(Pair.create("header1", "value1_B"));
-        expectedHeaders.add(Pair.create("header1", "value1_A"));
-        expectedHeaders.add(Pair.create("HEADER2", "value2"));
-        expectedHeaders.add(Pair.create("header3", "value3"));
-        assertEquals(expectedHeaders, orderedHeaders);
+        List<Header> expectedHeaders = new ArrayList<>();
+        expectedHeaders.add(new Header("header1", "value1_B"));
+        expectedHeaders.add(new Header("header3", "value3"));
+        expectedHeaders.add(new Header("HEADER2", "value2"));
+        expectedHeaders.add(new Header("header1", "value1_A"));
+        assertEquals(expectedHeaders, response.getHeaders());
     }
 }

--- a/src/test/java/com/android/volley/toolbox/BaseHttpStackTest.java
+++ b/src/test/java/com/android/volley/toolbox/BaseHttpStackTest.java
@@ -1,6 +1,7 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.AuthFailureError;
+import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.mock.TestRequest;
 
@@ -45,7 +46,7 @@ public class BaseHttpStackTest {
                     throws IOException, AuthFailureError {
                 assertSame(REQUEST, request);
                 assertSame(ADDITIONAL_HEADERS, additionalHeaders);
-                return new HttpResponse(12345, Collections.<String, List<String>>emptyMap());
+                return new HttpResponse(12345, Collections.<Header>emptyList());
             }
         };
         org.apache.http.HttpResponse resp = stack.performRequest(REQUEST, ADDITIONAL_HEADERS);
@@ -65,7 +66,7 @@ public class BaseHttpStackTest {
                 assertSame(ADDITIONAL_HEADERS, additionalHeaders);
                 return new HttpResponse(
                         12345,
-                        Collections.<String, List<String>>emptyMap(),
+                        Collections.<Header>emptyList(),
                         555,
                         mContent);
             }
@@ -86,12 +87,10 @@ public class BaseHttpStackTest {
                     throws IOException, AuthFailureError {
                 assertSame(REQUEST, request);
                 assertSame(ADDITIONAL_HEADERS, additionalHeaders);
-                Map<String, List<String>> headers = new TreeMap<>();
-                headers.put("HeaderA", Collections.singletonList("ValueA"));
-                List<String> values = new ArrayList<>();
-                values.add("ValueB_1");
-                values.add("ValueB_2");
-                headers.put("HeaderB", values);
+                List<Header> headers = new ArrayList<>();
+                headers.add(new Header("HeaderA", "ValueA"));
+                headers.add(new Header("HeaderB", "ValueB_1"));
+                headers.add(new Header("HeaderB", "ValueB_2"));
                 return new HttpResponse(12345, headers);
             }
         };

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -17,6 +17,7 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.Cache;
+import com.android.volley.Header;
 import com.android.volley.toolbox.DiskBasedCache.CacheHeader;
 import com.android.volley.toolbox.DiskBasedCache.CountingInputStream;
 
@@ -38,7 +39,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -428,28 +431,33 @@ public class DiskBasedCacheTest {
         assertEquals(DiskBasedCache.readString(cis), "ファイカス");
     }
 
-    @Test public void serializeMap() throws Exception {
+    @Test public void serializeHeaders() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Map<String, String> empty = new HashMap<>();
-        DiskBasedCache.writeStringStringMap(empty, baos);
-        DiskBasedCache.writeStringStringMap(null, baos);
-        Map<String, String> twoThings = new HashMap<>();
-        twoThings.put("first", "thing");
-        twoThings.put("second", "item");
-        DiskBasedCache.writeStringStringMap(twoThings, baos);
-        Map<String, String> emptyKey = new HashMap<>();
-        emptyKey.put("", "value");
-        DiskBasedCache.writeStringStringMap(emptyKey, baos);
-        Map<String, String> emptyValue = new HashMap<>();
-        emptyValue.put("key", "");
-        DiskBasedCache.writeStringStringMap(emptyValue, baos);
+        List<Header> empty = new ArrayList<>();
+        DiskBasedCache.writeHeaderList(empty, baos);
+        DiskBasedCache.writeHeaderList(null, baos);
+        List<Header> twoThings = new ArrayList<>();
+        twoThings.add(new Header("first", "thing"));
+        twoThings.add(new Header("second", "item"));
+        DiskBasedCache.writeHeaderList(twoThings, baos);
+        List<Header> emptyKey = new ArrayList<>();
+        emptyKey.add(new Header("", "value"));
+        DiskBasedCache.writeHeaderList(emptyKey, baos);
+        List<Header> emptyValue = new ArrayList<>();
+        emptyValue.add(new Header("key", ""));
+        DiskBasedCache.writeHeaderList(emptyValue, baos);
+        List<Header> sameKeys = new ArrayList<>();
+        sameKeys.add(new Header("key", "value"));
+        sameKeys.add(new Header("key", "value2"));
+        DiskBasedCache.writeHeaderList(sameKeys, baos);
         CountingInputStream cis =
                 new CountingInputStream(new ByteArrayInputStream(baos.toByteArray()), baos.size());
-        assertEquals(DiskBasedCache.readStringStringMap(cis), empty);
-        assertEquals(DiskBasedCache.readStringStringMap(cis), empty); // null reads back empty
-        assertEquals(DiskBasedCache.readStringStringMap(cis), twoThings);
-        assertEquals(DiskBasedCache.readStringStringMap(cis), emptyKey);
-        assertEquals(DiskBasedCache.readStringStringMap(cis), emptyValue);
+        assertEquals(DiskBasedCache.readHeaderList(cis), empty);
+        assertEquals(DiskBasedCache.readHeaderList(cis), empty); // null reads back empty
+        assertEquals(DiskBasedCache.readHeaderList(cis), twoThings);
+        assertEquals(DiskBasedCache.readHeaderList(cis), emptyKey);
+        assertEquals(DiskBasedCache.readHeaderList(cis), emptyValue);
+        assertEquals(DiskBasedCache.readHeaderList(cis), sameKeys);
     }
 
     @Test

--- a/src/test/java/com/android/volley/toolbox/HurlStackTest.java
+++ b/src/test/java/com/android/volley/toolbox/HurlStackTest.java
@@ -16,6 +16,7 @@
 
 package com.android.volley.toolbox;
 
+import com.android.volley.Header;
 import com.android.volley.Request.Method;
 import com.android.volley.mock.MockHttpURLConnection;
 import com.android.volley.mock.TestRequest;
@@ -24,6 +25,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -151,5 +158,20 @@ public class HurlStackTest {
         HurlStack.setConnectionParametersForRequest(mMockConnection, request);
         assertEquals("PATCH", mMockConnection.getRequestMethod());
         assertTrue(mMockConnection.getDoOutput());
+    }
+
+    @Test public void convertHeaders() {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("HeaderA", Collections.singletonList("ValueA"));
+        List<String> values = new ArrayList<>();
+        values.add("ValueB_1");
+        values.add("ValueB_2");
+        headers.put("HeaderB", values);
+        List<Header> result = HurlStack.convertHeaders(headers);
+        List<Header> expected = new ArrayList<>();
+        expected.add(new Header("HeaderA", "ValueA"));
+        expected.add(new Header("HeaderB", "ValueB_1"));
+        expected.add(new Header("HeaderB", "ValueB_2"));
+        assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
-Add support for multiple headers with the same key. This is permitted
by HTTP standards - for example, a server may include multiple
Set-Cookie headers in a response. However, Volley used Map<String,
String> throughout its stack which made it impossible to see all but
the last such header. We now expose a flat Header list in
NetworkResponse and Cache.Entry for clients who wish to use it. The
old Map is still populated for backwards compatibility and
convenience.

-Fix inconsistent case-insensitivity in Header maps. Previously, the
header map would be case-insensitive for network requests but
case-sensitive for cache entry reads. We now ensure that the map is
always case-insensitive (for clients using it and not the flat list)
by creating it in NetworkResponse's constructor. Redundant TreeMap
creations have been removed.

-Avoid mutating the cache entry's response header map directly.

This change should be compile-time-compatible with existing Volley 1.0
users. There is a signature change to HttpResponse which has not been
part of an official release yet. Custom implementations of Cache may
wish to populate the new allHeaders field in Cache.Entry, though this
is optional.

Fixes #21
Fixes #76