### PR TITLE
Fix an issue when the first request returns an error. (#98)

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -229,6 +229,7 @@ public class CacheDispatcher extends Thread {
                 }
                 Request<?> nextInLine = waitingRequests.remove(0);
                 mWaitingRequests.put(cacheKey, waitingRequests);
+                nextInLine.setNetworkRequestCompleteListener(this);
                 try {
                     mCacheDispatcher.mNetworkQueue.put(nextInLine);
                 } catch (InterruptedException iex) {


### PR DESCRIPTION
* Fix an issue when the first request returns an error and the next waiting request is sent to the network.

* Add CacheDispatcher test for cases when next waiting request is sent to network.