### PR TITLE
Update upstream

### DIFF
--- a/consumer-proguard-rules.pro
+++ b/consumer-proguard-rules.pro
@@ -1,0 +1,9 @@
+# Prevent Proguard from inlining methods that are intentionally extracted to ensure locals have a
+# constrained liveness scope by the GC. This is needed to avoid keeping previous request references
+# alive for an indeterminate amount of time. See also https://github.com/google/volley/issues/114
+-keepclassmembers,allowshrinking,allowobfuscation class com.android.volley.NetworkDispatcher {
+    void processRequest();
+}
+-keepclassmembers,allowshrinking,allowobfuscation class com.android.volley.CacheDispatcher {
+    void processRequest();
+}

--- a/rules.gradle
+++ b/rules.gradle
@@ -9,6 +9,10 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
   }
+
+  defaultConfig {
+    consumerProguardFiles 'consumer-proguard-rules.pro'
+  }
 }
 
 // Check if the android plugin version supports unit testing.


### PR DESCRIPTION
* Workaround memory leak in dispatchers.

Android has a long-standing known issue where local variables aren't
explicitly cleared even when they go out of scope, which can cause
their contents to leak. Since BlockingQueue#take() blocks
forever until a new item is ready, this means the last
request will remain in memory until a new request pushes it
out. Extracting a helper method is a workaround for this - see, for
example, the following CL in the Android support lib:

https://android.googlesource.com/platform/frameworks/support/+/cd07a0cfd9c9501a03c574d2d48df51c82b73e33

The following other solutions were attempted but were not sufficient:

- Clear the variable prior to take() - optimized out because the write
  is not observable, so it has no impact on the bytecode.

- Call poll() prior to take() - for some reason, this doesn't work
  when proguard optimization is on.

With code optimization, there's no guarantee that this will work, though
we now provide a Proguard config that should prevent inlining. However, it
appears to be the best we can do and follows precedent / advice from the
ART team.

Should contain no functional changes otherwise as this is just
extracting code to a helper method, and thus should be safe for 1.1.0.

Verified against provided sample app.

Fixes #114