### PR TITLE
Update upstream

### DIFF
--- a/src/test/java/com/android/volley/toolbox/HttpStackConformanceTest.java
+++ b/src/test/java/com/android/volley/toolbox/HttpStackConformanceTest.java
@@ -15,7 +15,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
@@ -58,8 +60,7 @@ public class HttpStackConformanceTest {
                         doAnswer(
                                         new Answer<Void>() {
                                             @Override
-                                            public Void answer(InvocationOnMock invocation)
-                                                    throws Throwable {
+                                            public Void answer(InvocationOnMock invocation) {
                                                 outputHeaderMap.put(
                                                         invocation.<String>getArgument(0),
                                                         invocation.<String>getArgument(1));
@@ -68,6 +69,24 @@ public class HttpStackConformanceTest {
                                         })
                                 .when(mMockConnection)
                                 .setRequestProperty(anyString(), anyString());
+                        doAnswer(
+                                        new Answer<Map<String, List<String>>>() {
+                                            @Override
+                                            public Map<String, List<String>> answer(
+                                                    InvocationOnMock invocation) {
+                                                Map<String, List<String>> result = new HashMap<>();
+                                                for (Map.Entry<String, String> entry :
+                                                        outputHeaderMap.entrySet()) {
+                                                    result.put(
+                                                            entry.getKey(),
+                                                            Collections.singletonList(
+                                                                    entry.getValue()));
+                                                }
+                                                return result;
+                                            }
+                                        })
+                                .when(mMockConnection)
+                                .getRequestProperties();
                     }
                 },
 


### PR DESCRIPTION
In #193 we moved setting of request headers to after setting the
connection parameters (Content-Type header and request body).
However, setting a request body (or more precisely, calling
HttpUrlConection#getOutputStream) prevents us from setting
additional headers, because the connection is opened already.

Instead, we just skip setting the Content-Type header if one
has already been set via Request#getHeaders. This is a bit more
error-prone, but unlikely to change in the future, and hard to
express in a cleaner way because with the DEPRECATED_GET_OR_POST
method, we need to call getPostBody to determine if the request
will be a GET or POST request, and we should only call this once.

Verified on a real device (as Robolectric did not catch this).

Fixes #198