### PR TITLE
Update upstream

### DIFF
--- a/src/main/java/com/android/volley/toolbox/ImageLoader.java
+++ b/src/main/java/com/android/volley/toolbox/ImageLoader.java
@@ -239,8 +239,11 @@ public class ImageLoader {
         // Update the caller to let them know that they should use the default bitmap.
         imageListener.onResponse(imageContainer, true);
 
-        // Check to see if a request is already in-flight.
+        // Check to see if a request is already in-flight or completed but pending batch delivery.
         BatchedImageRequest request = mInFlightRequests.get(cacheKey);
+        if (request == null) {
+            request = mBatchedResponses.get(cacheKey);
+        }
         if (request != null) {
             // If it is, add this request to the list of listeners.
             request.addContainer(imageContainer);


### PR DESCRIPTION
If a request for a given URL is queued and completes while pending
responses are waiting for the next batch delivery window, all pending
responses are erroneously dropped on the floor because the pending
BatchedImageRequest is clobbered. Prevent this by checking for pending
batched responses when queueing new requests.

Fixes #209