### PR TITLE
Delete the redundant define test

### DIFF
--- a/src/main/java/com/android/volley/toolbox/Volley.java
+++ b/src/main/java/com/android/volley/toolbox/Volley.java
@@ -86,8 +86,22 @@ public class Volley {
     }
 
     private static RequestQueue newRequestQueue(Context context, Network network) {
-        File cacheDir = new File(context.getCacheDir(), DEFAULT_CACHE_DIR);
-        RequestQueue queue = new RequestQueue(new DiskBasedCache(cacheDir), network);
+        final Context appContext = context.getApplicationContext();
+        // Use a lazy supplier for the cache directory so that newRequestQueue() can be called on
+        // main thread without causing strict mode violation.
+        DiskBasedCache.FileSupplier cacheSupplier =
+                new DiskBasedCache.FileSupplier() {
+                    private File cacheDir = null;
+
+                    @Override
+                    public File get() {
+                        if (cacheDir == null) {
+                            cacheDir = new File(appContext.getCacheDir(), DEFAULT_CACHE_DIR);
+                        }
+                        return cacheDir;
+                    }
+                };
+        RequestQueue queue = new RequestQueue(new DiskBasedCache(cacheSupplier), network);
         queue.start();
         return queue;
     }

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -587,7 +587,10 @@ public class DiskBasedCacheTest {
     public void publicMethods() throws Exception {
         // Catch-all test to find API-breaking changes.
         assertNotNull(DiskBasedCache.class.getConstructor(File.class, int.class));
+        assertNotNull(
+                DiskBasedCache.class.getConstructor(DiskBasedCache.FileSupplier.class, int.class));
         assertNotNull(DiskBasedCache.class.getConstructor(File.class));
+        assertNotNull(DiskBasedCache.class.getConstructor(DiskBasedCache.FileSupplier.class));
 
         assertNotNull(DiskBasedCache.class.getMethod("getFileForKey", String.class));
     }


### PR DESCRIPTION
Adding FileSupplier to DiskBasedCache so that the cacheDir can be constructed lazily (and preferably within the initialize() method which is invoked by CacheDispatcher on a non-UI thread). Currently Volley.newRequestQueue() is causing strict mode violation when called on main thread.