### PR TITLE
When clicking the menu

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
@@ -135,7 +135,15 @@ public class HttpHeaderParser {
             return newRfc1123Formatter().parse(dateStr).getTime();
         } catch (ParseException e) {
             // Date in invalid format, fallback to 0
-            VolleyLog.e(e, "Unable to parse dateStr: %s, falling back to 0", dateStr);
+            // If the value is either "0" or "-1" we only log to verbose,
+            // these values are pretty common and cause log spam.
+            String message = "Unable to parse dateStr: %s, falling back to 0";
+            if ("0".equals(dateStr) || "-1".equals(dateStr)) {
+                VolleyLog.v(message, dateStr);
+            } else {
+                VolleyLog.e(e, message, dateStr);
+            }
+
             return 0;
         }
     }


### PR DESCRIPTION
… invalid value. (#283)

* httpheaderparser: log invalid date headers only verbosely when common invalid value.