### PR TITLE
Fix rustdoc display with js disabled

### DIFF
--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -256,12 +256,12 @@ public class DiskBasedCache implements Cache {
             e.size = file.length();
             putEntry(key, e);
             pruneIfNeeded();
-            return;
         } catch (IOException e) {
-        }
-        boolean deleted = file.delete();
-        if (!deleted) {
-            VolleyLog.d("Could not clean up file %s", file.getAbsolutePath());
+            boolean deleted = file.delete();
+            if (!deleted) {
+                VolleyLog.d("Could not clean up file %s", file.getAbsolutePath());
+            }
+            initializeIfRootDirectoryDeleted();
         }
     }
 
@@ -293,6 +293,16 @@ public class DiskBasedCache implements Cache {
     /** Returns a file object for the given cache key. */
     public File getFileForKey(String key) {
         return new File(mRootDirectorySupplier.get(), getFilenameForKey(key));
+    }
+
+    /** Re-initialize the cache if the directory was deleted. */
+    private void initializeIfRootDirectoryDeleted() {
+        if (!mRootDirectorySupplier.get().exists()) {
+            VolleyLog.d("Re-initializing cache after external clearing.");
+            mEntries.clear();
+            mTotalSize = 0;
+            initialize();
+        }
     }
 
     /** Represents a supplier for {@link File}s. */

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -595,6 +595,20 @@ public class DiskBasedCacheTest {
         assertNotNull(DiskBasedCache.class.getMethod("getFileForKey", String.class));
     }
 
+    @Test
+    public void initializeIfRootDirectoryDeleted() {
+        temporaryFolder.delete();
+
+        Cache.Entry entry = randomData(101);
+        cache.put("key1", entry);
+
+        assertThat(cache.get("key1"), is(nullValue()));
+
+        // confirm that we can now store entries
+        cache.put("key2", entry);
+        assertThatEntriesAreEqual(cache.get("key2"), entry);
+    }
+
     /* Test helpers */
 
     private void assertThatEntriesAreEqual(Cache.Entry actual, Cache.Entry expected) {


### PR DESCRIPTION
* Re-initialize the cache if the directory was deleted.

If the user clears the cache from the Android Settings page, the
DiskBasedCache's root directory is deleted. This means that the app will
be running without a cache until it is restarted and the cache
initialized.
This fix initializes the cache when it finds that the root directory no
longer exists.
Note that the first entry after deletion that is put into the cache is
still lost, the cache is only re-initialized when putting that entry
fails. Adding retries would be more complicated, since we would have to
avoid getting into a loop if creating the root directory fails.

Fixes #296